### PR TITLE
Refine public booking visibility: HIDDEN for exams/mentors, public open-slot format with CID

### DIFF
--- a/app/Filament/Training/Resources/SessionBookingSlotResource.php
+++ b/app/Filament/Training/Resources/SessionBookingSlotResource.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Filament\Training\Resources;
+
+use App\Filament\Training\Resources\SessionBookingSlotResource\Pages;
+use App\Models\Training\SessionBookingSlot;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class SessionBookingSlotResource extends Resource
+{
+    protected static ?string $model = SessionBookingSlot::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-calendar-days';
+
+    protected static ?string $navigationGroup = 'Training';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    protected static ?string $modelLabel = 'Booking Slot';
+
+    protected static ?string $pluralModelLabel = 'Booking Slots';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Select::make('session_type')
+                ->label('Slot Type')
+                ->options(SessionBookingSlot::typeOptions())
+                ->required(),
+            TextInput::make('title')->required()->maxLength(255),
+            DateTimePicker::make('scheduled_for')->seconds(false)->required(),
+            TextInput::make('duration_minutes')->numeric()->required()->minValue(15)->default(90),
+            Textarea::make('notes')->rows(3)->maxLength(1000),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('scheduled_for')
+            ->columns([
+                Tables\Columns\TextColumn::make('scheduled_for')->label('Scheduled For')->dateTime('d M Y H:i')->sortable(),
+                Tables\Columns\TextColumn::make('session_type')->label('Type')->formatStateUsing(fn (string $state): string => SessionBookingSlot::typeOptions()[$state] ?? $state)->badge(),
+                Tables\Columns\TextColumn::make('title')->searchable(),
+                Tables\Columns\TextColumn::make('duration_minutes')->label('Duration (min)'),
+                Tables\Columns\TextColumn::make('picked_up_by_name')->label('Picked Up By')->default('Unassigned'),
+                Tables\Columns\IconColumn::make('picked_up_at')->label('Assigned')->timestampBoolean(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('session_type')->label('Type')->options(SessionBookingSlot::typeOptions()),
+                Tables\Filters\TernaryFilter::make('picked_up_at')->label('Assigned')->placeholder('Any')->trueLabel('Assigned')->falseLabel('Open'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSessionBookingSlots::route('/'),
+            'create' => Pages\CreateSessionBookingSlot::route('/create'),
+            'edit' => Pages\EditSessionBookingSlot::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Training/Resources/SessionBookingSlotResource/Pages/CreateSessionBookingSlot.php
+++ b/app/Filament/Training/Resources/SessionBookingSlotResource/Pages/CreateSessionBookingSlot.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Training\Resources\SessionBookingSlotResource\Pages;
+
+use App\Filament\Training\Resources\SessionBookingSlotResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSessionBookingSlot extends CreateRecord
+{
+    protected static string $resource = SessionBookingSlotResource::class;
+}

--- a/app/Filament/Training/Resources/SessionBookingSlotResource/Pages/EditSessionBookingSlot.php
+++ b/app/Filament/Training/Resources/SessionBookingSlotResource/Pages/EditSessionBookingSlot.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Training\Resources\SessionBookingSlotResource\Pages;
+
+use App\Filament\Training\Resources\SessionBookingSlotResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSessionBookingSlot extends EditRecord
+{
+    protected static string $resource = SessionBookingSlotResource::class;
+}

--- a/app/Filament/Training/Resources/SessionBookingSlotResource/Pages/ListSessionBookingSlots.php
+++ b/app/Filament/Training/Resources/SessionBookingSlotResource/Pages/ListSessionBookingSlots.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Training\Resources\SessionBookingSlotResource\Pages;
+
+use App\Filament\Admin\Helpers\Pages\BaseListRecordsPage;
+use App\Filament\Training\Resources\SessionBookingSlotResource;
+use Filament\Actions;
+
+class ListSessionBookingSlots extends BaseListRecordsPage
+{
+    protected static string $resource = SessionBookingSlotResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Site/BookingCalendarController.php
+++ b/app/Http/Controllers/Site/BookingCalendarController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Site;
+
+use App\Models\Training\SessionBookingSlot;
+use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class BookingCalendarController extends \App\Http\Controllers\BaseController
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->addBreadcrumb('ATC', route('site.atc.landing'));
+        $this->addBreadcrumb('Bookings', route('site.atc.bookings'));
+        $this->addBreadcrumb('Mentor & Examiner Calendar', route('site.atc.bookings.calendar'));
+    }
+
+    public function index(Request $request)
+    {
+        $month = $this->resolveMonth($request->string('month')->toString());
+
+        $slots = SessionBookingSlot::query()
+            ->whereBetween('scheduled_for', [$month->copy()->startOfMonth(), $month->copy()->endOfMonth()])
+            ->orderBy('scheduled_for')
+            ->get()
+            ->groupBy(fn (SessionBookingSlot $slot): string => $slot->scheduled_for->toDateString());
+
+        $this->setTitle('Mentor & Examiner Booking Calendar');
+
+        return $this->viewMake('site.atc.bookings-calendar', [
+            'month' => $month,
+            'slotsByDate' => $slots,
+            'daysInMonth' => collect(range(1, $month->daysInMonth))
+                ->map(fn (int $day): Carbon => $month->copy()->day($day)),
+        ]);
+    }
+
+    public function pickup(Request $request, SessionBookingSlot $sessionBookingSlot): RedirectResponse
+    {
+        $validated = $request->validate([
+            'picked_up_by_name' => ['required', 'string', 'max:100'],
+            'picked_up_by_email' => ['required', 'email', 'max:255'],
+            'picked_up_role' => ['required', 'in:mentor,examiner'],
+            'picked_up_by_cid' => [
+                Rule::requiredIf(fn (): bool => $sessionBookingSlot->isOpenSlot()),
+                'nullable',
+                'digits_between:6,10',
+            ],
+        ]);
+
+        if ($sessionBookingSlot->isPickedUp()) {
+            return back()->withErrors(['pickup' => 'This session has already been picked up.']);
+        }
+
+        if (! $sessionBookingSlot->canBePickedUpBy($validated['picked_up_role'])) {
+            return back()->withErrors(['pickup' => 'This session can only be picked up by: '.$sessionBookingSlot->roleRestrictionLabel().'.']);
+        }
+
+        $sessionBookingSlot->update([
+            ...$validated,
+            'picked_up_at' => now(),
+        ]);
+
+        return back()->with('status', 'Session picked up successfully.');
+    }
+
+    private function resolveMonth(string $month): Carbon
+    {
+        if ($month === '') {
+            return now()->startOfMonth();
+        }
+
+        try {
+            return Carbon::createFromFormat('Y-m', $month)->startOfMonth();
+        } catch (InvalidFormatException) {
+            return now()->startOfMonth();
+        }
+    }
+}

--- a/app/Models/Training/SessionBookingSlot.php
+++ b/app/Models/Training/SessionBookingSlot.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Models\Training;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class SessionBookingSlot extends Model
+{
+    use HasFactory;
+
+    public const TYPE_EXAM = 'exam';
+
+    public const TYPE_MENTOR_SESSION = 'mentor_session';
+
+    public const TYPE_OPEN_SLOT = 'open_slot';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'scheduled_for' => 'datetime',
+        'picked_up_at' => 'datetime',
+    ];
+
+    public static function typeOptions(): array
+    {
+        return [
+            self::TYPE_EXAM => 'Exam',
+            self::TYPE_MENTOR_SESSION => 'Mentor Session',
+            self::TYPE_OPEN_SLOT => 'Open Slot',
+        ];
+    }
+
+    public function isExam(): bool
+    {
+        return $this->session_type === self::TYPE_EXAM;
+    }
+
+    public function isMentorSession(): bool
+    {
+        return $this->session_type === self::TYPE_MENTOR_SESSION;
+    }
+
+    public function isOpenSlot(): bool
+    {
+        return $this->session_type === self::TYPE_OPEN_SLOT;
+    }
+
+    public function isPickedUp(): bool
+    {
+        return $this->picked_up_at !== null;
+    }
+
+    public function canBePickedUpBy(string $role): bool
+    {
+        if ($this->isExam()) {
+            return $role === 'examiner';
+        }
+
+        if ($this->isMentorSession()) {
+            return $role === 'mentor';
+        }
+
+        if ($this->isOpenSlot()) {
+            return in_array($role, ['mentor', 'examiner'], true);
+        }
+
+        return false;
+    }
+
+    public function roleRestrictionLabel(): string
+    {
+        return match (true) {
+            $this->isExam() => 'Examiner only',
+            $this->isMentorSession() => 'Mentor only',
+            $this->isOpenSlot() => 'Mentor or Examiner',
+            default => 'Unknown',
+        };
+    }
+
+    public function requiresHiddenBookedByDisplay(): bool
+    {
+        return $this->isExam() || $this->isMentorSession();
+    }
+
+    public function publicBookedByLabel(): string
+    {
+        if (! $this->isPickedUp()) {
+            return 'Open';
+        }
+
+        if ($this->requiresHiddenBookedByDisplay()) {
+            return 'HIDDEN';
+        }
+
+        return $this->formatPublicBookerName();
+    }
+
+    public function formatPublicBookerName(): string
+    {
+        $name = trim((string) $this->picked_up_by_name);
+
+        if ($name === '') {
+            return 'Unknown';
+        }
+
+        $nameParts = preg_split('/\s+/', $name) ?: [];
+        $firstName = $nameParts[0] ?? $name;
+        $surnameInitial = isset($nameParts[1]) ? Str::upper(Str::substr($nameParts[1], 0, 1)) : null;
+
+        $displayName = $surnameInitial ? sprintf('%s %s', $firstName, $surnameInitial) : $firstName;
+
+        if (! $this->picked_up_by_cid) {
+            return $displayName;
+        }
+
+        return sprintf('%s (%s)', $displayName, $this->picked_up_by_cid);
+    }
+
+}

--- a/app/Models/Training/SessionBookingSlot.php
+++ b/app/Models/Training/SessionBookingSlot.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Training;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -116,6 +117,24 @@ class SessionBookingSlot extends Model
         }
 
         return sprintf('%s (%s)', $displayName, $this->picked_up_by_cid);
+    }
+
+
+    public function scheduledForZulu(): Carbon
+    {
+        return $this->scheduled_for->copy()->utc();
+    }
+
+    public function endsAtZulu(): Carbon
+    {
+        return $this->scheduledForZulu()->addMinutes((int) $this->duration_minutes);
+    }
+
+    public function hasEndedForPublic(?Carbon $reference = null): bool
+    {
+        $referenceTime = ($reference ?? now('UTC'))->copy()->utc();
+
+        return $this->endsAtZulu()->lte($referenceTime);
     }
 
 }

--- a/app/Policies/Training/SessionBookingSlotPolicy.php
+++ b/app/Policies/Training/SessionBookingSlotPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies\Training;
+
+use App\Models\Mship\Account;
+use App\Models\Training\SessionBookingSlot;
+
+class SessionBookingSlotPolicy
+{
+    public function viewAny(Account $account): bool
+    {
+        return $account->can('training.booking-slots.view');
+    }
+
+    public function view(Account $account, SessionBookingSlot $sessionBookingSlot): bool
+    {
+        return $account->can('training.booking-slots.view');
+    }
+
+    public function create(Account $account): bool
+    {
+        return $account->can('training.booking-slots.manage');
+    }
+
+    public function update(Account $account, SessionBookingSlot $sessionBookingSlot): bool
+    {
+        return $account->can('training.booking-slots.manage');
+    }
+
+    public function delete(Account $account, SessionBookingSlot $sessionBookingSlot): bool
+    {
+        return $account->can('training.booking-slots.manage');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\Mship\Account\Ban;
 use App\Models\Mship\Account\EndorsementRequest;
 use App\Models\Mship\Account\Note;
 use App\Models\Mship\Feedback\Feedback;
+use App\Models\Training\SessionBookingSlot;
 use App\Models\Training\WaitingList;
 use App\Models\Training\WaitingList\WaitingListRetentionCheck;
 use App\Models\VisitTransfer;
@@ -17,6 +18,7 @@ use App\Policies\Mship\Account\NotePolicy;
 use App\Policies\PasswordPolicy;
 use App\Policies\PositionGroupPolicy;
 use App\Policies\RolePolicy;
+use App\Policies\Training\SessionBookingSlotPolicy;
 use App\Policies\Training\WaitingList\WaitingListRetentionChecksPolicy;
 use App\Policies\Training\WaitingListFlagsPolicy;
 use App\Policies\Training\WaitingListPolicy;
@@ -53,6 +55,7 @@ class AuthServiceProvider extends ServiceProvider
         Role::class => RolePolicy::class,
         Note::class => NotePolicy::class,
         WaitingListRetentionCheck::class => WaitingListRetentionChecksPolicy::class,
+        SessionBookingSlot::class => SessionBookingSlotPolicy::class,
     ];
 
     /**

--- a/database/migrations/2026_02_12_000000_create_session_booking_slots_table.php
+++ b/database/migrations/2026_02_12_000000_create_session_booking_slots_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('session_booking_slots', function (Blueprint $table): void {
+            $table->id();
+            $table->string('session_type'); // exam | mentor_session | open_slot
+            $table->string('title');
+            $table->dateTime('scheduled_for');
+            $table->unsignedSmallInteger('duration_minutes')->default(90);
+            $table->text('notes')->nullable();
+            $table->string('picked_up_by_name')->nullable();
+            $table->string('picked_up_by_email')->nullable();
+            $table->unsignedBigInteger('picked_up_by_cid')->nullable();
+            $table->string('picked_up_role')->nullable(); // mentor | examiner
+            $table->dateTime('picked_up_at')->nullable();
+            $table->timestamps();
+
+            $table->index('scheduled_for');
+            $table->index(['session_type', 'scheduled_for']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('session_booking_slots');
+    }
+};

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -54,6 +54,8 @@ class RolesAndPermissionsSeeder extends Seeder
             'training.theory.view.twr',
             'training.theory.view.app',
             'training.theory.view.ctr',
+            'training.booking-slots.view',
+            'training.booking-slots.manage',
 
             // Account Permissions
             'account.self',

--- a/resources/views/site/atc/bookings-calendar.blade.php
+++ b/resources/views/site/atc/bookings-calendar.blade.php
@@ -121,7 +121,14 @@
                                 @forelse ($slots as $slot)
                                     <div class="booking-calendar-slot">
                                         <div class="booking-calendar-slot-title">{{ $slot->title }}</div>
-                                        <div>{{ $slot->scheduled_for->format('H:i') }}&ndash;{{ $slot->scheduled_for->copy()->addMinutes($slot->duration_minutes)->format('H:i') }} UTC</div>
+                                        <div>
+                                            <strong>Zulu:</strong>
+                                            {{ $slot->scheduledForZulu()->format('H:i') }}&ndash;{{ $slot->endsAtZulu()->format('H:i') }} UTC
+                                        </div>
+                                        <div>
+                                            <strong>Local:</strong>
+                                            {{ $slot->scheduledForZulu()->copy()->timezone('Europe/London')->format('H:i') }}&ndash;{{ $slot->endsAtZulu()->copy()->timezone('Europe/London')->format('H:i') }} Europe/London
+                                        </div>
                                         <div>{{ $slot->isExam() ? 'Exam' : ($slot->isMentorSession() ? 'Mentor Session' : 'Open Slot') }}</div>
                                         <div><small class="text-muted">{{ $slot->roleRestrictionLabel() }}</small></div>
 

--- a/resources/views/site/atc/bookings-calendar.blade.php
+++ b/resources/views/site/atc/bookings-calendar.blade.php
@@ -1,6 +1,9 @@
 @extends('layout')
 
 @section('content')
+    @php($calendarMonth = isset($month) ? $month : now()->startOfMonth())
+    @php($calendarDaysInMonth = isset($daysInMonth) ? $daysInMonth : collect(range(1, $calendarMonth->daysInMonth))->map(fn (int $day) => $calendarMonth->copy()->day($day)))
+    @php($calendarSlotsByDate = isset($slotsByDate) ? $slotsByDate : collect())
     <div class="row">
         <div class="col-md-10 col-md-offset-1">
             <div class="panel panel-ukblue">
@@ -23,22 +26,22 @@
 
                     <div class="row" style="margin-bottom: 20px;">
                         <div class="col-sm-4">
-                            <a class="btn btn-default" href="{{ route('site.atc.bookings.calendar', ['month' => $month->copy()->subMonth()->format('Y-m')]) }}">
+                            <a class="btn btn-default" href="{{ route('site.atc.bookings.calendar', ['month' => $calendarMonth->copy()->subMonth()->format('Y-m')]) }}">
                                 &larr; Previous Month
                             </a>
                         </div>
                         <div class="col-sm-4 text-center">
-                            <strong>{{ $month->format('F Y') }}</strong>
+                            <strong>{{ $calendarMonth->format('F Y') }}</strong>
                         </div>
                         <div class="col-sm-4 text-right">
-                            <a class="btn btn-default" href="{{ route('site.atc.bookings.calendar', ['month' => $month->copy()->addMonth()->format('Y-m')]) }}">
+                            <a class="btn btn-default" href="{{ route('site.atc.bookings.calendar', ['month' => $calendarMonth->copy()->addMonth()->format('Y-m')]) }}">
                                 Next Month &rarr;
                             </a>
                         </div>
                     </div>
 
-                    @foreach ($daysInMonth as $date)
-                        @php($slots = $slotsByDate->get($date->toDateString(), collect()))
+                    @foreach ($calendarDaysInMonth as $date)
+                        @php($slots = $calendarSlotsByDate->get($date->toDateString(), collect()))
                         <div class="panel panel-default">
                             <div class="panel-heading">
                                 <strong>{{ $date->format('D j M') }}</strong>

--- a/resources/views/site/atc/bookings-calendar.blade.php
+++ b/resources/views/site/atc/bookings-calendar.blade.php
@@ -1,0 +1,132 @@
+@extends('layout')
+
+@section('content')
+    <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+            <div class="panel panel-ukblue">
+                <div class="panel-heading">
+                    <i class="glyphicon glyphicon-calendar"></i> &thinsp; Mentor &amp; Examiner Session Calendar
+                </div>
+                <div class="panel-body">
+                    <p>
+                        Public calendar for available mentoring sessions, exams, and open training slots.
+                        Mentors and examiners can pick up unassigned sessions directly from this page.
+                    </p>
+
+                    @if (session('status'))
+                        <div class="alert alert-success">{{ session('status') }}</div>
+                    @endif
+
+                    @if ($errors->has('pickup'))
+                        <div class="alert alert-danger">{{ $errors->first('pickup') }}</div>
+                    @endif
+
+                    <div class="row" style="margin-bottom: 20px;">
+                        <div class="col-sm-4">
+                            <a class="btn btn-default" href="{{ route('site.atc.bookings.calendar', ['month' => $month->copy()->subMonth()->format('Y-m')]) }}">
+                                &larr; Previous Month
+                            </a>
+                        </div>
+                        <div class="col-sm-4 text-center">
+                            <strong>{{ $month->format('F Y') }}</strong>
+                        </div>
+                        <div class="col-sm-4 text-right">
+                            <a class="btn btn-default" href="{{ route('site.atc.bookings.calendar', ['month' => $month->copy()->addMonth()->format('Y-m')]) }}">
+                                Next Month &rarr;
+                            </a>
+                        </div>
+                    </div>
+
+                    @foreach ($daysInMonth as $date)
+                        @php($slots = $slotsByDate->get($date->toDateString(), collect()))
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <strong>{{ $date->format('D j M') }}</strong>
+                                @if ($slots->isEmpty())
+                                    <span class="text-muted">&ndash; No sessions published</span>
+                                @endif
+                            </div>
+                            @if ($slots->isNotEmpty())
+                                <div class="table-responsive">
+                                    <table class="table table-striped" style="margin-bottom: 0;">
+                                        <thead>
+                                            <tr>
+                                                <th>Time (UTC)</th>
+                                                <th>Type</th>
+                                                <th>Session</th>
+                                                <th>Role Restriction</th>
+                                                <th>Status</th>
+                                                <th style="width: 320px;">Pick up</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach ($slots as $slot)
+                                                <tr>
+                                                    <td>
+                                                        {{ $slot->scheduled_for->format('H:i') }}
+                                                        &ndash;
+                                                        {{ $slot->scheduled_for->copy()->addMinutes($slot->duration_minutes)->format('H:i') }}
+                                                    </td>
+                                                    <td>{{ $slot->isExam() ? 'Exam' : ($slot->isMentorSession() ? 'Mentor Session' : 'Open Slot') }}</td>
+                                                    <td>
+                                                        <strong>{{ $slot->title }}</strong>
+                                                        @if ($slot->notes)
+                                                            <br><small class="text-muted">{{ $slot->notes }}</small>
+                                                        @endif
+                                                    </td>
+                                                    <td>{{ $slot->roleRestrictionLabel() }}</td>
+                                                    <td>
+                                                        @if ($slot->isPickedUp())
+                                                            <span class="label label-success">
+                                                                Booked by {{ $slot->publicBookedByLabel() }}
+                                                            </span>
+                                                        @else
+                                                            <span class="label label-warning">Open</span>
+                                                        @endif
+                                                    </td>
+                                                    <td>
+                                                        @if ($slot->isPickedUp())
+                                                            <span class="text-muted">Already assigned</span>
+                                                        @else
+                                                            <form method="POST" action="{{ route('site.atc.bookings.pickup', $slot) }}">
+                                                                @csrf
+                                                                <div class="form-group" style="margin-bottom: 6px;">
+                                                                    <input type="text" name="picked_up_by_name" class="form-control input-sm" placeholder="Your name" required>
+                                                                </div>
+                                                                <div class="form-group" style="margin-bottom: 6px;">
+                                                                    <input type="email" name="picked_up_by_email" class="form-control input-sm" placeholder="Your email" required>
+                                                                </div>
+
+                                                                @if ($slot->isOpenSlot())
+                                                                    <div class="form-group" style="margin-bottom: 6px;"> 
+                                                                        <input type="text" name="picked_up_by_cid" class="form-control input-sm" placeholder="Your CID" inputmode="numeric" pattern="[0-9]{6,10}" required>
+                                                                    </div>
+                                                                @endif
+                                                                <div class="form-group" style="margin-bottom: 6px;">
+                                                                    <select name="picked_up_role" class="form-control input-sm" required>
+                                                                        <option value="">Select role</option>
+                                                                        @if (! $slot->isExam())
+                                                                            <option value="mentor">Mentor</option>
+                                                                        @endif
+                                                                        @if (! $slot->isMentorSession())
+                                                                            <option value="examiner">Examiner</option>
+                                                                        @endif
+                                                                    </select>
+                                                                </div>
+                                                                <button type="submit" class="btn btn-primary btn-sm">Pick up session</button>
+                                                            </form>
+                                                        @endif
+                                                    </td>
+                                                </tr>
+                                            @endforeach
+                                        </tbody>
+                                    </table>
+                                </div>
+                            @endif
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </div>
+@stop

--- a/resources/views/site/atc/bookings-calendar.blade.php
+++ b/resources/views/site/atc/bookings-calendar.blade.php
@@ -4,8 +4,66 @@
     @php($calendarMonth = isset($month) ? $month : now()->startOfMonth())
     @php($calendarDaysInMonth = isset($daysInMonth) ? $daysInMonth : collect(range(1, $calendarMonth->daysInMonth))->map(fn (int $day) => $calendarMonth->copy()->day($day)))
     @php($calendarSlotsByDate = isset($slotsByDate) ? $slotsByDate : collect())
+    @php($calendarFirstDayOffset = isset($firstDayOffset) ? $firstDayOffset : ($calendarMonth->copy()->startOfMonth()->dayOfWeekIso - 1))
+
+    <style>
+        .booking-calendar-grid {
+            display: grid;
+            grid-template-columns: repeat(7, minmax(0, 1fr));
+            gap: 12px;
+        }
+
+        .booking-calendar-day-header,
+        .booking-calendar-day {
+            border: 1px solid #d8d8d8;
+            border-radius: 4px;
+            background: #fff;
+        }
+
+        .booking-calendar-day-header {
+            font-weight: 700;
+            text-align: center;
+            padding: 8px 6px;
+            background: #f5f5f5;
+        }
+
+        .booking-calendar-day {
+            min-height: 180px;
+            padding: 8px;
+        }
+
+        .booking-calendar-day.muted {
+            background: #fafafa;
+            border-style: dashed;
+        }
+
+        .booking-calendar-date {
+            font-weight: 700;
+            margin-bottom: 8px;
+        }
+
+        .booking-calendar-slot {
+            border: 1px solid #e2e2e2;
+            border-radius: 4px;
+            padding: 6px;
+            margin-bottom: 8px;
+            background: #fcfcfc;
+            font-size: 12px;
+        }
+
+        .booking-calendar-slot-title {
+            font-weight: 600;
+            margin-bottom: 2px;
+        }
+
+        .booking-calendar-actions form {
+            display: inline-block;
+            margin-top: 6px;
+        }
+    </style>
+
     <div class="row">
-        <div class="col-md-10 col-md-offset-1">
+        <div class="col-md-12">
             <div class="panel panel-ukblue">
                 <div class="panel-heading">
                     <i class="glyphicon glyphicon-calendar"></i> &thinsp; Mentor &amp; Examiner Session Calendar
@@ -13,24 +71,30 @@
                 <div class="panel-body">
                     <p>
                         Public calendar for available mentoring sessions, exams, and open training slots.
-                        Mentors and examiners can pick up unassigned sessions directly from this page.
+                        @auth
+                            You are signed in, so you can book eligible open slots directly from this page.
+                        @else
+                            Sign in to one-click book; guests can still submit booking details manually.
+                        @endauth
                     </p>
 
                     @if (session('status'))
                         <div class="alert alert-success">{{ session('status') }}</div>
                     @endif
 
-                    @if ($errors->has('pickup'))
-                        <div class="alert alert-danger">{{ $errors->first('pickup') }}</div>
+                    @if ($errors->any())
+                        <div class="alert alert-danger">
+                            {{ $errors->first() }}
+                        </div>
                     @endif
 
-                    <div class="row" style="margin-bottom: 20px;">
+                    <div class="row" style="margin-bottom: 16px;">
                         <div class="col-sm-4">
                             <a class="btn btn-default" href="{{ route('site.atc.bookings.calendar', ['month' => $calendarMonth->copy()->subMonth()->format('Y-m')]) }}">
                                 &larr; Previous Month
                             </a>
                         </div>
-                        <div class="col-sm-4 text-center">
+                        <div class="col-sm-4 text-center" style="padding-top: 6px;">
                             <strong>{{ $calendarMonth->format('F Y') }}</strong>
                         </div>
                         <div class="col-sm-4 text-right">
@@ -40,94 +104,77 @@
                         </div>
                     </div>
 
-                    @foreach ($calendarDaysInMonth as $date)
-                        @php($slots = $calendarSlotsByDate->get($date->toDateString(), collect()))
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <strong>{{ $date->format('D j M') }}</strong>
-                                @if ($slots->isEmpty())
-                                    <span class="text-muted">&ndash; No sessions published</span>
-                                @endif
-                            </div>
-                            @if ($slots->isNotEmpty())
-                                <div class="table-responsive">
-                                    <table class="table table-striped" style="margin-bottom: 0;">
-                                        <thead>
-                                            <tr>
-                                                <th>Time (UTC)</th>
-                                                <th>Type</th>
-                                                <th>Session</th>
-                                                <th>Role Restriction</th>
-                                                <th>Status</th>
-                                                <th style="width: 320px;">Pick up</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            @foreach ($slots as $slot)
-                                                <tr>
-                                                    <td>
-                                                        {{ $slot->scheduled_for->format('H:i') }}
-                                                        &ndash;
-                                                        {{ $slot->scheduled_for->copy()->addMinutes($slot->duration_minutes)->format('H:i') }}
-                                                    </td>
-                                                    <td>{{ $slot->isExam() ? 'Exam' : ($slot->isMentorSession() ? 'Mentor Session' : 'Open Slot') }}</td>
-                                                    <td>
-                                                        <strong>{{ $slot->title }}</strong>
-                                                        @if ($slot->notes)
-                                                            <br><small class="text-muted">{{ $slot->notes }}</small>
-                                                        @endif
-                                                    </td>
-                                                    <td>{{ $slot->roleRestrictionLabel() }}</td>
-                                                    <td>
-                                                        @if ($slot->isPickedUp())
-                                                            <span class="label label-success">
-                                                                Booked by {{ $slot->publicBookedByLabel() }}
-                                                            </span>
-                                                        @else
-                                                            <span class="label label-warning">Open</span>
-                                                        @endif
-                                                    </td>
-                                                    <td>
-                                                        @if ($slot->isPickedUp())
-                                                            <span class="text-muted">Already assigned</span>
-                                                        @else
-                                                            <form method="POST" action="{{ route('site.atc.bookings.pickup', $slot) }}">
-                                                                @csrf
-                                                                <div class="form-group" style="margin-bottom: 6px;">
-                                                                    <input type="text" name="picked_up_by_name" class="form-control input-sm" placeholder="Your name" required>
-                                                                </div>
-                                                                <div class="form-group" style="margin-bottom: 6px;">
-                                                                    <input type="email" name="picked_up_by_email" class="form-control input-sm" placeholder="Your email" required>
-                                                                </div>
+                    <div class="booking-calendar-grid">
+                        @foreach (['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as $dow)
+                            <div class="booking-calendar-day-header">{{ $dow }}</div>
+                        @endforeach
 
-                                                                @if ($slot->isOpenSlot())
-                                                                    <div class="form-group" style="margin-bottom: 6px;"> 
-                                                                        <input type="text" name="picked_up_by_cid" class="form-control input-sm" placeholder="Your CID" inputmode="numeric" pattern="[0-9]{6,10}" required>
-                                                                    </div>
-                                                                @endif
-                                                                <div class="form-group" style="margin-bottom: 6px;">
-                                                                    <select name="picked_up_role" class="form-control input-sm" required>
-                                                                        <option value="">Select role</option>
-                                                                        @if (! $slot->isExam())
-                                                                            <option value="mentor">Mentor</option>
-                                                                        @endif
-                                                                        @if (! $slot->isMentorSession())
-                                                                            <option value="examiner">Examiner</option>
-                                                                        @endif
-                                                                    </select>
-                                                                </div>
-                                                                <button type="submit" class="btn btn-primary btn-sm">Pick up session</button>
-                                                            </form>
+                        @for ($i = 0; $i < $calendarFirstDayOffset; $i++)
+                            <div class="booking-calendar-day muted"></div>
+                        @endfor
+
+                        @foreach ($calendarDaysInMonth as $date)
+                            @php($slots = $calendarSlotsByDate->get($date->toDateString(), collect()))
+                            <div class="booking-calendar-day">
+                                <div class="booking-calendar-date">{{ $date->format('j M') }}</div>
+
+                                @forelse ($slots as $slot)
+                                    <div class="booking-calendar-slot">
+                                        <div class="booking-calendar-slot-title">{{ $slot->title }}</div>
+                                        <div>{{ $slot->scheduled_for->format('H:i') }}&ndash;{{ $slot->scheduled_for->copy()->addMinutes($slot->duration_minutes)->format('H:i') }} UTC</div>
+                                        <div>{{ $slot->isExam() ? 'Exam' : ($slot->isMentorSession() ? 'Mentor Session' : 'Open Slot') }}</div>
+                                        <div><small class="text-muted">{{ $slot->roleRestrictionLabel() }}</small></div>
+
+                                        @if ($slot->isPickedUp())
+                                            <div><span class="label label-success">Booked by {{ $slot->publicBookedByLabel() }}</span></div>
+                                        @else
+                                            <div><span class="label label-warning">Open</span></div>
+                                            <div class="booking-calendar-actions">
+                                                @auth
+                                                    @if (! $slot->isExam())
+                                                        <form method="POST" action="{{ route('site.atc.bookings.pickup', $slot) }}">
+                                                            @csrf
+                                                            <input type="hidden" name="picked_up_role" value="mentor">
+                                                            <button type="submit" class="btn btn-xs btn-primary">Book as Mentor</button>
+                                                        </form>
+                                                    @endif
+
+                                                    @if (! $slot->isMentorSession())
+                                                        <form method="POST" action="{{ route('site.atc.bookings.pickup', $slot) }}">
+                                                            @csrf
+                                                            <input type="hidden" name="picked_up_role" value="examiner">
+                                                            <button type="submit" class="btn btn-xs btn-info">Book as Examiner</button>
+                                                        </form>
+                                                    @endif
+                                                @else
+                                                    <form method="POST" action="{{ route('site.atc.bookings.pickup', $slot) }}" style="margin-top: 6px;">
+                                                        @csrf
+                                                        <input type="text" name="picked_up_by_name" class="form-control input-sm" placeholder="Your name" required style="margin-bottom: 4px;">
+                                                        <input type="email" name="picked_up_by_email" class="form-control input-sm" placeholder="Your email" required style="margin-bottom: 4px;">
+                                                        @if ($slot->isOpenSlot())
+                                                            <input type="text" name="picked_up_by_cid" class="form-control input-sm" placeholder="Your CID" inputmode="numeric" pattern="[0-9]{6,10}" required style="margin-bottom: 4px;">
                                                         @endif
-                                                    </td>
-                                                </tr>
-                                            @endforeach
-                                        </tbody>
-                                    </table>
-                                </div>
-                            @endif
-                        </div>
-                    @endforeach
+                                                        <select name="picked_up_role" class="form-control input-sm" required style="margin-bottom: 4px;">
+                                                            <option value="">Select role</option>
+                                                            @if (! $slot->isExam())
+                                                                <option value="mentor">Mentor</option>
+                                                            @endif
+                                                            @if (! $slot->isMentorSession())
+                                                                <option value="examiner">Examiner</option>
+                                                            @endif
+                                                        </select>
+                                                        <button type="submit" class="btn btn-xs btn-primary">Book slot</button>
+                                                    </form>
+                                                @endauth
+                                            </div>
+                                        @endif
+                                    </div>
+                                @empty
+                                    <small class="text-muted">No sessions</small>
+                                @endforelse
+                            </div>
+                        @endforeach
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/site/atc/bookings.blade.php
+++ b/resources/views/site/atc/bookings.blade.php
@@ -15,6 +15,13 @@
                         bookings and ensure that you arrive and control for any bookings you make.
                     </p>
 
+
+                    <p>
+                        Looking to help with training delivery? Visit the
+                        <a href="{{ route('site.atc.bookings.calendar') }}">Mentor &amp; Examiner booking calendar</a>
+                        to pick up available exam, mentoring, and open training slots.
+                    </p>
+
                     <h2>
                         General
                     </h2>

--- a/routes/web-public.php
+++ b/routes/web-public.php
@@ -20,6 +20,8 @@ Route::group([
         Route::get('/heathrow')->uses('ATCPagesController@viewHeathrow')->name('heathrow');
         Route::get('/becoming-a-mentor')->uses('ATCPagesController@viewBecomingAMentor')->name('mentor');
         Route::get('/bookings')->uses('ATCPagesController@viewBookings')->name('bookings');
+        Route::get('/bookings/calendar')->uses('BookingCalendarController@index')->name('bookings.calendar');
+        Route::post('/bookings/{sessionBookingSlot}/pickup')->uses('BookingCalendarController@pickup')->name('bookings.pickup');
     });
 
     Route::group([

--- a/tests/Feature/Site/BookingCalendarTest.php
+++ b/tests/Feature/Site/BookingCalendarTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature\Site;
+
+use App\Models\Training\SessionBookingSlot;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BookingCalendarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_calendar_page_lists_slots(): void
+    {
+        SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_EXAM,
+            'title' => 'EGLL S2 Exam',
+            'scheduled_for' => Carbon::create(2026, 2, 16, 19, 0, 0),
+            'duration_minutes' => 120,
+        ]);
+
+        $response = $this->get(route('site.atc.bookings.calendar', ['month' => '2026-02']));
+
+        $response->assertOk();
+        $response->assertSee('EGLL S2 Exam');
+    }
+
+    public function test_exam_can_be_picked_up_by_examiner(): void
+    {
+        $slot = SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_EXAM,
+            'title' => 'Manchester Exam',
+            'scheduled_for' => now()->addDay(),
+            'duration_minutes' => 90,
+        ]);
+
+        $response = $this->post(route('site.atc.bookings.pickup', $slot), [
+            'picked_up_by_name' => 'Alex Examiner',
+            'picked_up_by_email' => 'alex@example.com',
+            'picked_up_role' => 'examiner',
+            'picked_up_by_cid' => '1669680',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertNotNull($slot->fresh()->picked_up_at);
+        $this->assertSame('Alex Examiner', $slot->fresh()->picked_up_by_name);
+    }
+
+    public function test_exam_cannot_be_picked_up_by_mentor(): void
+    {
+        $slot = SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_EXAM,
+            'title' => 'Bristol Exam',
+            'scheduled_for' => now()->addDay(),
+            'duration_minutes' => 90,
+        ]);
+
+        $response = $this->from(route('site.atc.bookings.calendar'))->post(route('site.atc.bookings.pickup', $slot), [
+            'picked_up_by_name' => 'Mia Mentor',
+            'picked_up_by_email' => 'mia@example.com',
+            'picked_up_role' => 'mentor',
+            'picked_up_by_cid' => '1669679',
+        ]);
+
+        $response->assertRedirect(route('site.atc.bookings.calendar'));
+        $response->assertSessionHasErrors('pickup');
+        $this->assertNull($slot->fresh()->picked_up_at);
+    }
+
+    public function test_open_slot_can_be_picked_up_by_mentor_or_examiner(): void
+    {
+        $slot = SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_OPEN_SLOT,
+            'title' => 'Open Evening Slot',
+            'scheduled_for' => now()->addDay(),
+            'duration_minutes' => 60,
+        ]);
+
+        $mentorResponse = $this->post(route('site.atc.bookings.pickup', $slot), [
+            'picked_up_by_name' => 'Taylor Mentor',
+            'picked_up_by_email' => 'taylor@example.com',
+            'picked_up_role' => 'mentor',
+            'picked_up_by_cid' => '1669679',
+        ]);
+
+        $mentorResponse->assertRedirect();
+        $this->assertSame('mentor', $slot->fresh()->picked_up_role);
+
+        $secondSlot = SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_OPEN_SLOT,
+            'title' => 'Open Backup Slot',
+            'scheduled_for' => now()->addDays(2),
+            'duration_minutes' => 60,
+        ]);
+
+        $examinerResponse = $this->post(route('site.atc.bookings.pickup', $secondSlot), [
+            'picked_up_by_name' => 'Jordan Examiner',
+            'picked_up_by_email' => 'jordan@example.com',
+            'picked_up_role' => 'examiner',
+            'picked_up_by_cid' => '1669680',
+        ]);
+
+        $examinerResponse->assertRedirect();
+        $this->assertSame('examiner', $secondSlot->fresh()->picked_up_role);
+    }
+
+    public function test_exam_and_mentor_slots_render_booked_by_hidden(): void
+    {
+        SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_EXAM,
+            'title' => 'Hidden Exam Slot',
+            'scheduled_for' => Carbon::create(2026, 2, 14, 10, 30, 0),
+            'duration_minutes' => 90,
+            'picked_up_by_name' => 'Tristan Shaw',
+            'picked_up_by_cid' => 1669679,
+            'picked_up_role' => 'examiner',
+            'picked_up_at' => now(),
+        ]);
+
+        SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_MENTOR_SESSION,
+            'title' => 'Hidden Mentor Slot',
+            'scheduled_for' => Carbon::create(2026, 2, 14, 13, 0, 0),
+            'duration_minutes' => 90,
+            'picked_up_by_name' => 'Mentor Person',
+            'picked_up_by_cid' => 1234567,
+            'picked_up_role' => 'mentor',
+            'picked_up_at' => now(),
+        ]);
+
+        $response = $this->get(route('site.atc.bookings.calendar', ['month' => '2026-02']));
+
+        $response->assertOk();
+        $response->assertSee('Booked by HIDDEN');
+    }
+
+    public function test_open_slot_renders_short_name_and_cid_when_booked(): void
+    {
+        SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_OPEN_SLOT,
+            'title' => 'Open Visibility Slot',
+            'scheduled_for' => Carbon::create(2026, 2, 15, 11, 0, 0),
+            'duration_minutes' => 90,
+            'picked_up_by_name' => 'Tristan Shaw',
+            'picked_up_by_cid' => 1669679,
+            'picked_up_role' => 'mentor',
+            'picked_up_at' => now(),
+        ]);
+
+        $response = $this->get(route('site.atc.bookings.calendar', ['month' => '2026-02']));
+
+        $response->assertOk();
+        $response->assertSee('Booked by Tristan S (1669679)');
+    }
+
+
+    public function test_open_slot_pickup_requires_cid(): void
+    {
+        $slot = SessionBookingSlot::create([
+            'session_type' => SessionBookingSlot::TYPE_OPEN_SLOT,
+            'title' => 'CID required slot',
+            'scheduled_for' => now()->addDay(),
+            'duration_minutes' => 60,
+        ]);
+
+        $response = $this->from(route('site.atc.bookings.calendar'))->post(route('site.atc.bookings.pickup', $slot), [
+            'picked_up_by_name' => 'Taylor Mentor',
+            'picked_up_by_email' => 'taylor@example.com',
+            'picked_up_role' => 'mentor',
+        ]);
+
+        $response->assertRedirect(route('site.atc.bookings.calendar'));
+        $response->assertSessionHasErrors('picked_up_by_cid');
+    }
+
+}

--- a/tests/Feature/TrainingPanel/BookingSlots/SessionBookingSlotPermissionsTest.php
+++ b/tests/Feature/TrainingPanel/BookingSlots/SessionBookingSlotPermissionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\TrainingPanel\BookingSlots;
+
+use App\Filament\Training\Resources\SessionBookingSlotResource;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelTestCase;
+
+class SessionBookingSlotPermissionsTest extends BaseTrainingPanelTestCase
+{
+    use DatabaseTransactions;
+
+    public function test_index_requires_view_permission(): void
+    {
+        $this->actingAs($this->panelUser)
+            ->get(SessionBookingSlotResource::getUrl('index', panel: 'training'))
+            ->assertForbidden();
+
+        $this->panelUser->givePermissionTo('training.booking-slots.view');
+
+        $this->actingAs($this->panelUser)
+            ->get(SessionBookingSlotResource::getUrl('index', panel: 'training'))
+            ->assertSuccessful();
+    }
+
+    public function test_create_requires_manage_permission(): void
+    {
+        $this->panelUser->givePermissionTo('training.booking-slots.view');
+
+        $this->actingAs($this->panelUser)
+            ->get(SessionBookingSlotResource::getUrl('create', panel: 'training'))
+            ->assertForbidden();
+
+        $this->panelUser->givePermissionTo('training.booking-slots.manage');
+
+        $this->actingAs($this->panelUser)
+            ->get(SessionBookingSlotResource::getUrl('create', panel: 'training'))
+            ->assertSuccessful();
+    }
+}

--- a/tests/Feature/TrainingPanel/BookingSlots/SessionBookingSlotResourceTest.php
+++ b/tests/Feature/TrainingPanel/BookingSlots/SessionBookingSlotResourceTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Feature\TrainingPanel\BookingSlots;
+
+use App\Filament\Training\Resources\SessionBookingSlotResource;
+use App\Policies\Training\SessionBookingSlotPolicy;
+use Tests\Feature\TrainingPanel\BaseTrainingPanelResourceTestCase;
+
+class SessionBookingSlotResourceTest extends BaseTrainingPanelResourceTestCase
+{
+    protected static ?string $resourceClass = SessionBookingSlotResource::class;
+
+    protected ?string $policy = SessionBookingSlotPolicy::class;
+}


### PR DESCRIPTION
### Motivation
- Ensure public calendar privacy for official exam and mentor-session bookings by hiding the assignee, while keeping normal/open-slot bookings publicly visible in the requested `FirstName S (CID)` format.
- Make the visibility rules deterministic and single-sourced so the public UI and pickup flow behave consistently.

### Description
- Added model helpers `requiresHiddenBookedByDisplay()`, `publicBookedByLabel()` and `formatPublicBookerName()` to `SessionBookingSlot` to centralise public visibility and name formatting logic and to render `HIDDEN` for exams/mentor sessions and `FirstName S (CID)` for open slots when available. (see `app/Models/Training/SessionBookingSlot.php`).
- Require and persist a numeric `picked_up_by_cid` for open-slot pickups by adding the column to the migration and validating it in `BookingCalendarController::pickup`, and updated the pickup update to save the CID. (see `database/migrations/2026_02_12_000000_create_session_booking_slots_table.php` and `app/Http/Controllers/Site/BookingCalendarController.php`).
- Updated the public calendar view to use `{{ $slot->publicBookedByLabel() }}` for the status text and to collect the CID on the pickup form only for open slots. (see `resources/views/site/atc/bookings-calendar.blade.php`).
- Added routing for the calendar and pickup endpoints and added Filament admin resource/pages plus a `SessionBookingSlotPolicy` and registration in `AuthServiceProvider`, and seeded the new permissions `training.booking-slots.view` and `training.booking-slots.manage`. (see `routes/web-public.php`, Filament resources, `app/Policies/Training/SessionBookingSlotPolicy.php`, `app/Providers/AuthServiceProvider.php`, and `database/seeders/RolesAndPermissionsSeeder.php`).
- Extended/added feature tests to assert hidden display for exam/mentor slots, open-slot public formatting, and that CID is required for open-slot pickup. (see `tests/Feature/Site/BookingCalendarTest.php` and Training Panel tests).

### Testing
- Ran PHP syntax checks with `php -l` for the modified files and they reported no syntax errors.
- Attempted to run the site feature tests via `php artisan test tests/Feature/Site/BookingCalendarTest.php` but it failed in this environment due to missing `vendor/autoload.php` so the test bootstrap could not run.
- Executed an automated Playwright screenshot run of the calendar endpoint which produced an artifact but the page returned a site-level Not Found because no application server was available at the time.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5ab5d3fc8329959dda4c6ea98c94)